### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior.
+title: "[Bug] - [Describe Issue]"
+labels: bug, triage
+assignees: ''
+---
+
+### Description
+Please provide a clear and concise description of the issue you're experiencing. Be as detailed as possible about the problem.
+
+### Steps to Reproduce
+Please list the steps required to reproduce the issue:
+
+1. **Step 1**: [Describe the first step]
+2. **Step 2**: [Describe the second step]
+3. **Step 3**: [Describe the third step]
+4. [Continue adding steps if necessary]
+
+### Expected Behavior
+What were you expecting to happen?
+
+### Actual Behavior
+What actually happened? Please include any error messages, logs, or unexpected behavior you observed.
+
+### Debug Information
+Attach the debug output here if possible.
+
+### Environment Information
+To assist with troubleshooting, please provide the following information about your environment:
+
+Operating System: (e.g., Ubuntu 20.04, macOS 11.2)
+
+CPU architecture information (e.g., x86-64 (AMD64))
+
+### Screenshots or Logs
+If applicable, please provide screenshots or logs that illustrate the bug.
+
+### Additional Information
+Any other information that might be useful to identify or fix the bug. For example:
+
+Any steps that worked around the issue
+
+Specific configurations or files that may be relevant

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+- name: GitHub Discussions
+  url: https://github.com/jenstroeger/fullstack-webapp-template/discussions
+  about: Please ask and answer questions here.
+- name: Security Reports
+  url: https://github.com/jenstroeger/fullstack-webapp-template/blob/main/SECURITY.md
+  about: Please report security vulnerabilities following the instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement.
+title: "[Feature Request] - [Describe Feature]"
+labels: enhancement, feature
+assignees: ''
+
+---
+
+### Description
+Please provide a clear and concise description of the feature or enhancement you'd like to see in this project. Explain why it would be useful and how it could improve the tool.
+
+### Proposed Feature
+What functionality or feature would you like to add to this project? Please describe it in detail.
+
+### Use Case

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+<!-- Briefly summarize the purpose and scope of this PR. -->
+
+## Type of change
+<!-- Go over following points. check them with an `x` if they do apply. Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## Description of changes
+<!-- Provide a detailed explanation of the changes made in this PR, why they were needed, and how they address the issue(s). -->
+
+## Related issues
+<!-- List any related issue(s) this PR addresses, e.g., `Closes #123`, `Fixes #456`. -->
+
+# How Has This Been Tested?
+<!-- Please describe the tests that you ran to verify your changes. -->
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist
+<!-- Go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->
+
+- [ ] I have reviewed the [contribution guide](../CONTRIBUTING.md).
+- [ ] My PR title and commits follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention.
+- [ ] My commits include the "Signed-off-by" line.
+- [ ] I have signed my commits following the instructions provided by [GitHub](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits). Note that we run [GitHub's commit verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) tool to check the commit signatures. A green `verified` label should appear next to **all** of your commits on GitHub.
+- [ ] I have updated the relevant documentation, if applicable.
+- [ ] I have tested my changes and verified they work as expected.


### PR DESCRIPTION
## Summary
This PR adds GitHub issue and pull request templates to help standardize contributions and improve clarity in communication.

## Description of changes
Added `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` to the repository:
- The issue template provide structured formats for bug reports and feature requests.
- The PR template guides contributors to include summaries, types of changes, and detailed descriptions.